### PR TITLE
improve display of inactive accounts on the leaderboard

### DIFF
--- a/projects/backend/src/service/player/player-search.service.ts
+++ b/projects/backend/src/service/player/player-search.service.ts
@@ -83,7 +83,14 @@ export class PlayerSearchService {
 
     const tokens = foundPlayers?.players ?? [];
     const items = await Promise.all(
-      tokens.map(token => ScoreSaberPlayerService.getPlayer(token.id, "basic", token))
+      tokens.map(async token => {
+        const player = await ScoreSaberPlayerService.getPlayer(token.id, "basic", token)
+        return {
+          ...player,
+          contextualRank: token.rank,
+          contextualCountryRank: token.countryRank,
+        }
+      })
     );
 
     return {

--- a/projects/common/src/player/impl/scoresaber-player.ts
+++ b/projects/common/src/player/impl/scoresaber-player.ts
@@ -8,6 +8,16 @@ import Player, { StatisticChange } from "../player";
  */
 export default interface ScoreSaberPlayer extends ScoreSaberPlayerBase {
   /**
+   * The contextual rank for this player
+   */
+  contextualRank?: number;
+
+  /**
+   * The contextual country rank for this player
+   */
+  contextualCountryRank?: number;
+
+  /**
    * The change in pp compared to yesterday.
    */
   statisticChange: StatisticChange | undefined;

--- a/projects/website/src/components/player/header/player-overview.tsx
+++ b/projects/website/src/components/player/header/player-overview.tsx
@@ -156,7 +156,7 @@ export default function PlayerOverview({ player }: PlayerOverviewProps) {
 
         return (
           <div key={`player-overview-${index}-${subName.showWhenInactiveOrBanned}`}>
-            {subName.render && subName.render(player)}
+            {subName.render?.(player)}
           </div>
         );
       })}

--- a/projects/website/src/components/player/player-ranking.tsx
+++ b/projects/website/src/components/player/player-ranking.tsx
@@ -10,6 +10,7 @@ import ScoreSaberPlayer from "@ssr/common/player/impl/scoresaber-player";
 import { formatNumberWithCommas } from "@ssr/common/utils/number-utils";
 import { getScoreSaberRoles } from "@ssr/common/utils/scoresaber.util";
 import { PlayerAvatar } from "../ranking/player-avatar";
+import SimpleTooltip from "../simple-tooltip";
 import CountryFlag from "../ui/country-flag";
 
 /** Row types supported by {@link PlayerRanking}: display fields used by the layout. */
@@ -24,8 +25,8 @@ export type PlayerRankingRow = {
 export function ScoreSaberPlayerRanking<T extends ScoreSaberPlayer>({
   player,
   firstColumnWidth,
-  getRank = p => p.rank,
-  getCountryRank = p => p.countryRank,
+  getRank = p => p.contextualRank ?? p.rank,
+  getCountryRank = p => p.contextualCountryRank ?? p.countryRank,
   mainPlayer,
   relativePerformancePoints,
   showAccountInactive = true,
@@ -43,6 +44,8 @@ export function ScoreSaberPlayerRanking<T extends ScoreSaberPlayer>({
       player={player}
       getRank={getRank}
       getCountryRank={getCountryRank}
+      getActiveRank={p => p.rank !== getRank(p) ? p.rank: undefined}
+      getActiveCountryRank={p => p.countryRank !== getCountryRank(p) ? p.countryRank: undefined}
       firstColumnWidth={firstColumnWidth}
       showAccountInactive={showAccountInactive}
       worth={
@@ -61,6 +64,8 @@ export function PlayerRanking<T extends PlayerRankingRow>({
   player,
   getRank,
   getCountryRank,
+  getActiveRank,
+  getActiveCountryRank,
   firstColumnWidth,
   worth,
   showAccountInactive = true,
@@ -68,6 +73,8 @@ export function PlayerRanking<T extends PlayerRankingRow>({
   player: T;
   getRank: (player: T) => number;
   getCountryRank: (player: T) => number;
+  getActiveRank?: (player: T) => number | undefined;
+  getActiveCountryRank?: (player: T) => number | undefined;
   firstColumnWidth: number;
   worth: React.ReactNode;
   showAccountInactive?: boolean;
@@ -77,6 +84,8 @@ export function PlayerRanking<T extends PlayerRankingRow>({
 
   const rank = getRank(player);
   const countryRank = getCountryRank(player);
+  const activeRank = getActiveRank?.(player);
+  const activeCountryRank = getActiveCountryRank?.(player);
   const country = player.country ?? "";
   const inactive = Boolean(player.inactive);
 
@@ -86,7 +95,8 @@ export function PlayerRanking<T extends PlayerRankingRow>({
       <div
         className={cn(
           "bg-accent-deep hover:bg-accent-deep/50 hidden items-center gap-2 rounded-md px-(--spacing-xs) py-(--spacing-xs) lg:flex",
-          mainPlayer?.id == player.id ? "bg-primary/10 hover:bg-primary/15" : ""
+          mainPlayer?.id === player.id ? "bg-primary/10 hover:bg-primary/15" : "",
+          inactive && 'opacity-50 grayscale-20'
         )}
       >
         {/* Rank, Weekly Change, and Country Rank */}
@@ -102,8 +112,9 @@ export function PlayerRanking<T extends PlayerRankingRow>({
           <PlayerRanks
             rank={rank}
             countryRank={countryRank}
+            activeRank={activeRank}
+            activeCountryRank={activeCountryRank}
             country={country}
-            inactive={inactive && showAccountInactive}
           />
         </div>
 
@@ -132,7 +143,6 @@ export function PlayerRanking<T extends PlayerRankingRow>({
                 rank={rank}
                 countryRank={countryRank}
                 country={country}
-                inactive={inactive && showAccountInactive}
               />
             </div>
           </div>
@@ -157,8 +167,8 @@ export function PlayerRanking<T extends PlayerRankingRow>({
   );
 }
 
-function RankDisplay({ rank }: { rank: number }) {
-  return (
+function RankDisplay({ rank, activeRank }: { rank: number, activeRank?: number }) {
+  const pill = (
     <div
       className={cn(
         "flex h-[24px] w-fit items-center justify-center gap-1 rounded-sm px-1 py-1 text-xs font-semibold",
@@ -167,11 +177,21 @@ function RankDisplay({ rank }: { rank: number }) {
     >
       <span>#{formatNumberWithCommas(rank)}</span>
     </div>
-  );
+  )
+
+  if (activeRank) {
+    return (
+      <SimpleTooltip display={`Active: #${formatNumberWithCommas(activeRank)}`}>
+        {pill}
+      </SimpleTooltip>
+    )
+  }
+
+  return pill;
 }
 
-function CountryRankDisplay({ country, countryRank }: { country: string; countryRank: number }) {
-  return (
+function CountryRankDisplay({ country, countryRank, activeCountryRank }: { country: string; countryRank: number; activeCountryRank?: number; }) {
+  const pill = (
     <div className="flex items-center">
       <div
         className={cn(
@@ -183,7 +203,17 @@ function CountryRankDisplay({ country, countryRank }: { country: string; country
         <span>#{formatNumberWithCommas(countryRank)}</span>
       </div>
     </div>
-  );
+  )
+
+  if (activeCountryRank) {
+    return (
+      <SimpleTooltip display={`Active: #${formatNumberWithCommas(activeCountryRank)}`}>
+        {pill}
+      </SimpleTooltip>
+    )
+  }
+
+  return pill;
 }
 
 function PlayerNameDisplay<T extends PlayerRankingRow>({
@@ -213,21 +243,19 @@ function PlayerRanks({
   rank,
   countryRank,
   country,
-  inactive,
+  activeRank,
+  activeCountryRank
 }: {
   rank: number;
   countryRank: number;
   country: string;
-  inactive: boolean;
+  activeRank?: number;
+  activeCountryRank?: number;
 }) {
-  if (inactive) {
-    return <p className="text-inactive-account text-xs font-bold">Inactive Account</p>;
-  }
-
   return (
     <>
-      <RankDisplay rank={rank} />
-      <CountryRankDisplay country={country} countryRank={countryRank} />
+      <RankDisplay rank={rank} activeRank={activeRank} />
+      <CountryRankDisplay country={country} countryRank={countryRank} activeCountryRank={activeCountryRank} />
     </>
   );
 }


### PR DESCRIPTION
Wasn't really a fan of the big ass "Inactive Account" text on the leaderboard, now ranks are properly offset depending if inactive accounts are shown or not, with a tooltip showing the current place
<img width="729" height="63" alt="image" src="https://github.com/user-attachments/assets/ee2b0faa-5f6d-4cb4-b21a-8ddd72a1c39d" />
